### PR TITLE
Add support for multiple icon rel attributes

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function combineURLs(baseURL, relativeURL) {
 
 function extractFavicons(query, baseUrl) {
     const urls = [];
-    const favicon = query("link[rel='icon'], link[rel='shortcut icon'], link[rel='alternate icon']");
+    const favicon = query("link[rel='icon' i], link[rel='shortcut icon' i], link[rel='alternate icon' i]");
     favicon.each((index, $el) => {
         let url = query($el).attr('href');
         const validity = isValidURL(url);

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function combineURLs(baseURL, relativeURL) {
 
 function extractFavicons(query, baseUrl) {
     const urls = [];
-    const favicon = query("link[rel='shortcut icon']");
+    const favicon = query("link[rel='icon'], link[rel='shortcut icon'], link[rel='alternate icon']");
     favicon.each((index, $el) => {
         let url = query($el).attr('href');
         const validity = isValidURL(url);


### PR DESCRIPTION
This pull request adds support for favicons with the "icon" and "alternate icon" `rel` attributes.

A request to `https://github.com/`, before:
```
{
  timeTaken: 607.7193869948387,
  redirects: [ { url: 'https://github.com/', timeTaken: 138.42339199781418 } ],
  images: [
    {
      url: 'https://github.com/favicon.ico',
      scrapped: false,
      width: 16,
      height: 16,
      type: 'ico',
      chunkSize: 238,
      success: true
    },
    {
      url: 'https://github.com/apple-touch-icon.png',
      scrapped: false,
      width: 120,
      height: 120,
      type: 'png',
      chunkSize: 318,
      success: true
    }
  ]
}
```

And after:
```
{
  timeTaken: 610.2979820072651,
  redirects: [ { url: 'https://github.com/', timeTaken: 143.55145999789238 } ],
  images: [
    {
      url: 'https://github.githubassets.com/favicons/favicon.png',
      scrapped: true,
      width: 32,
      height: 32,
      type: 'png',
      chunkSize: 958,
      success: true
    },
    {
      url: 'https://github.com/favicon.ico',
      scrapped: false,
      width: 16,
      height: 16,
      type: 'ico',
      chunkSize: 239,
      success: true
    },
    {
      url: 'https://github.com/apple-touch-icon.png',
      scrapped: false,
      width: 120,
      height: 120,
      type: 'png',
      chunkSize: 321,
      success: true
    }
  ]
}
```

Case insensitive attribute querying was also added as https://www.microsoft.com/ uses an uppercase attribute name.

I noticed "scrap" is used throughout the project, should it not be "scrape"?