### PR TITLE
Add support for redirects

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,7 @@ const cheerio = require('cheerio');
 const sizeOf = require('image-size');
 const {performance} = require('perf_hooks');
 const Url = require('url');
-const http = require('http');
-const https = require('https');
+const { http, https } = require('follow-redirects');
 
 const ERROR_ENUM = {
     MAX_REDIRECT: 'maxRedirect',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,13 @@
+{
+    "name": "scrap-favicon",
+    "version": "1.0.4",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "follow-redirects": {
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.1.tgz",
+            "integrity": "sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg=="
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     ],
     "dependencies": {
         "cheerio": "^1.0.0-rc.3",
+        "follow-redirects": "^1.13.1",
         "image-size": "^0.9.1"
     },
     "devDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -6,34 +6,9 @@ test('basic', async function (t) {
     t.is(value.images.length, 1);
 });
 
-test('with redirects 1', function (t) {
-    return scrapFavicon('https://akansh.com', {maxRedirect: 1}).then(result =>{
-        t.is(result.redirects.length, 1);
-    });
-});
-
-test('with redirects 3', function (t) {
-    return scrapFavicon('http://akansh.com', {maxRedirect: 2}).then(response => {
-        t.is(response.redirects.length, 2, "with redirects 3 failed");
-    });
-});
-
-test('with redirects 0', function (t) {
-    return scrapFavicon('https://www.akansh.com', {maxRedirect: 0}).then(response => {
-        t.is(response.redirects.length, 0, "with redirects 0 failed");
-    });
-});
-
 test('only urls as configuration', async (t)=>{
     const result = await scrapFavicon('https://www.akansh.com/', {urlsOnly: true});
     t.true(typeof result.images[0].width === 'undefined');
-});
-
-test('max redirects error', async function (t) {
-    return scrapFavicon('https://akansh.com', {maxRedirect: 0}).catch((err) => {
-        console.log("Here");
-        t.is(err.message, 'Max redirect limit reached');
-    });
 });
 
 test('http url does not exists', (t)=> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -788,6 +788,11 @@ find-up@^4.0.0:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
 
+follow-redirects@^1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.13.1.tgz#5f69b813376cee4fd0474a3aba835df04ab763b7"
+  integrity sha512-SSG5xmZh1mkPGyKzjZP8zLjltIfpW32Y5QpdNJyjcfGxK3qo3NDDkZOZSFiGn1A6SclQxY9GzEwAHQ3dmYRWpg==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"


### PR DESCRIPTION
This pull request adds support for favicon redirects. Currently, redirects are only supported when querying the document.

A request to `https://www.microsoft.com/`, before:
```
{
  timeTaken: 762.0193559974432,
  redirects: [
    {
      url: 'https://www.microsoft.com/de-de/',
      timeTaken: 107.16247500479221
    }
  ],
  images: []
}
```

And after:
```
{
  timeTaken: 689.2749710083008,
  images: [
    {
      url: 'https://www.microsoft.com/favicon.ico',
      scrapped: false,
      width: 128,
      height: 128,
      type: 'ico',
      chunkSize: 15682,
      success: true
    },
    {
      url: 'https://www.microsoft.com/apple-touch-icon.png',
      scrapped: false,
      width: 180,
      height: 180,
      type: 'png',
      chunkSize: 647,
      success: true
    }
  ]
}
```