### PR TITLE
Add support for favicons with query strings

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function scrapWebsite(url, config, redirects = []) {
 
 
 function isValidURL(string) {
-    const isValid = string.match(/(https?:\/\/)?[a-zA-z\d].+(png|ico|jpeg|jpg|webp|gif)$/i);
+    const isValid = string.match(/(https?:\/\/)?[a-zA-z\d].+(png|ico|jpeg|jpg|webp|gif)(\?.*)?$/i);
     return {
         isValid: !!isValid,
         isAbsolute: isValid && !!isValid[1]


### PR DESCRIPTION
This pull request adds support for favicons that include a query string.


A request to `https://vk.com/`, before:
```
{
  timeTaken: 826.304203003645,
  redirects: [ { url: 'https://m.vk.com/', timeTaken: 243.9709910005331 } ],
  images: [
    {
      url: 'https://m.vk.com/favicon.ico',
      scrapped: false,
      width: 32,
      height: 32,
      type: 'png',
      chunkSize: 498,
      success: true
    }
  ]
}
```

And after:
```
{
  timeTaken: 839.2166969925165,
  redirects: [ { url: 'https://m.vk.com/', timeTaken: 230.54315799474716 } ],
  images: [
    {
      url: 'https://m.vk.com/images/icons/pwa/apple/default.png?10',
      scrapped: true,
      width: 512,
      height: 512,
      type: 'png',
      chunkSize: 11768,
      success: true
    },
    {
      url: 'https://m.vk.com/images/icons/favicons/fav_logo.ico?8',
      scrapped: true,
      width: 16,
      height: 16,
      type: 'png',
      chunkSize: 313,
      success: true
    },
    {
      url: 'https://m.vk.com/favicon.ico',
      scrapped: false,
      width: 32,
      height: 32,
      type: 'png',
      chunkSize: 498,
      success: true
    }
  ]
}
```